### PR TITLE
Prevent notification spam

### DIFF
--- a/YT Music/Controllers/MediaCenter.swift
+++ b/YT Music/Controllers/MediaCenter.swift
@@ -107,6 +107,11 @@ class MediaCenter: NSObject, WKScriptMessageHandler, NSUserNotificationCenterDel
         
         
         NSUserNotificationCenter.default.delegate = self
+
+        // Remove all other notifications
+        NSUserNotificationCenter.default.removeAllDeliveredNotifications()
+        
+        // Schedule the new notification
         NSUserNotificationCenter.default.deliver(notification)
         
         titleChanged = false


### PR DESCRIPTION
This PR clears all previous notifications before scheduling a new one. This fixes two problems: first, YT music loads the byline synchronously, so you would get two notifications for each new song, and second, each notification would simply stack on top of the next, polluting the notification center.